### PR TITLE
Fix TogglePurchaseRequest model for purchase status updates

### DIFF
--- a/GroceryList-RESTAPI/Models/TogglePurchaseRequest.cs
+++ b/GroceryList-RESTAPI/Models/TogglePurchaseRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace GroceryListApi.Models
+{
+    public class TogglePurchaseRequest
+    {
+        public bool IsPurchased { get; set; }
+    }
+}


### PR DESCRIPTION
This pull request fixes the model class `TogglePurchaseRequest` to the `GroceryListApi.Models` namespace. The class contains a single property, `IsPurchased`, which is used to toggle the purchase status of items in the grocery list.